### PR TITLE
Fix an off-by-one bug for fiscal quarters

### DIFF
--- a/datemath.go
+++ b/datemath.go
@@ -322,7 +322,7 @@ func truncateUnits(u timeUnit) func(time.Time, Options) time.Time {
 		case timeUnitFiscalQuarter:
 			firstDay := firstDayOfFiscalYear(t, options.StartOfFiscalYear)
 			var mDelta int
-			if t.Month() > firstDay.Month() {
+			if t.Month() >= firstDay.Month() {
 				mDelta = int(t.Month() - firstDay.Month())
 			} else {
 				mDelta = int(t.Month() + 12 - firstDay.Month())

--- a/datemath_test.go
+++ b/datemath_test.go
@@ -266,6 +266,13 @@ func TestParseAndEvaluate(t *testing.T) {
 			in:  "now/fy+fy",
 			out: "2017-03-01T00:00:00.000Z",
 		},
+		{
+			now:        "2022-01-04T10:10:10.000Z",
+			fiscalYear: time.Time{},
+
+			in:  "now/fQ",
+			out: "2022-01-01T00:00:00.000Z",
+		},
 
 		// epoch times
 		{


### PR DESCRIPTION
When the month and the fiscal year is the same, any dates in the first month of the fiscal year will unintentionally add 12 months.