### PR TITLE
Start of week, fix edge-case where start of week is a later day in the week

### DIFF
--- a/datemath.go
+++ b/datemath.go
@@ -334,10 +334,11 @@ func truncateUnits(u timeUnit) func(time.Time, Options) time.Time {
 			return time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, t.Location())
 		case timeUnitWeek:
 			diff := int(t.Weekday() - options.StartOfWeek)
+			today := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
 			if diff < 0 {
-				return time.Date(t.Year(), t.Month(), t.Day()+diff-1, 0, 0, 0, 0, t.Location())
+				today = today.AddDate(0, 0, -7)
 			}
-			return time.Date(t.Year(), t.Month(), t.Day()-diff, 0, 0, 0, 0, t.Location())
+			return today.AddDate(0, 0, -diff)
 		case timeUnitDay:
 			return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
 		case timeUnitHour:


### PR DESCRIPTION
We noticed that setting the start of week to say "Saturday" wouldn't always mean that you'd end up with Saturday as the start of the week.

Taking an example where start of week is Saturday and today is Friday:
Friday (5) - Saturday (6) = -1.

Current logic adds that plus -1 (-2) to the current date, meaning that today's date -6 you'd do today's date -2 and end up on a Wednesday.

Rather than doing that, I remove seven days from the start date if the diff is negative and then add the negative diff to get the start date, which in this case means `today-7-(-1)=today-6`. For positive offsets, such as today being Friday and start of week being Monday, we skip the subtraction by seven and just subtract the diff between Friday (5) and Monday (1) = 4, `today-(+4)`, moving us to the preceding Monday. That's the same logic that's currently being done, but I've shifted it to use `time.AddDate` for clarity.

Old logic: https://go.dev/play/p/szsFGIY_Luc
New logic: https://go.dev/play/p/ifHCPWwSkqp